### PR TITLE
Fix unintended behavior of given percent functions

### DIFF
--- a/contracts/libraries/BorrowMath.sol
+++ b/contracts/libraries/BorrowMath.sol
@@ -3,11 +3,14 @@ pragma solidity =0.8.4;
 
 import {IPair} from '@timeswap-labs/timeswap-v1-core/contracts/interfaces/IPair.sol';
 import {Math} from '@timeswap-labs/timeswap-v1-core/contracts/libraries/Math.sol';
+import {SquareRoot} from './SquareRoot.sol';
 import {FullMath} from '@timeswap-labs/timeswap-v1-core/contracts/libraries/FullMath.sol';
 import {ConstantProduct} from './ConstantProduct.sol';
 import {SafeCast} from '@timeswap-labs/timeswap-v1-core/contracts/libraries/SafeCast.sol';
+
 library BorrowMath {
     using Math for uint256;
+    using SquareRoot for uint256;
     using FullMath for uint256;
     using ConstantProduct for IPair;
     using ConstantProduct for ConstantProduct.CP;
@@ -29,12 +32,12 @@ library BorrowMath {
         _yIncrease /= maturity - block.timestamp;
         yIncrease = _yIncrease.toUint112();
 
+        uint256 xAdjust = cp.x;
+        xAdjust -= assetOut;
+
         uint256 yAdjust = cp.y;
         yAdjust <<= 16;
         yAdjust += _yIncrease * feeBase;
-
-        uint256 xAdjust = cp.x;
-        xAdjust -= assetOut;
 
         uint256 _zIncrease = cp.x;
         _zIncrease *= cp.y;
@@ -103,37 +106,84 @@ library BorrowMath {
         uint256 xAdjust = cp.x;
         xAdjust -= assetOut;
 
-        uint256 minimum = assetOut;
-        minimum *= cp.y;
-        minimum <<= 12;
-        uint256 maximum = minimum;
-        maximum <<= 4;
-        uint256 denominator = xAdjust;
-        denominator *= feeBase;
-        minimum = minimum.divUp(denominator);
-        maximum /= denominator;
+        if (percent <= 0x80000000) {
+            uint256 yMid = cp.y;
+            yMid *= cp.y;
+            yMid << 32;
+            uint256 denominator = xAdjust;
+            denominator *= feeBase;
+            denominator *= feeBase;
+            yMid = yMid.mulDivUp(cp.x, denominator);
+            yMid = yMid.sqrtUp();
+            uint256 subtrahend = cp.y;
+            subtrahend <<= 16;
+            subtrahend /= feeBase;
+            yMid -= subtrahend;
 
-        uint256 _yIncrease = maximum;
-        _yIncrease -= minimum;
-        _yIncrease *= percent;
-        _yIncrease >>= 32;
-        _yIncrease += minimum;
-        yIncrease = _yIncrease.toUint112();
+            uint256 yMin = assetOut;
+            yMin *= cp.y;
+            yMin <<= 12;
+            denominator = xAdjust;
+            denominator *= feeBase;
+            yMin = yMin.divUp(denominator);
 
-        uint256 yAdjust = cp.y;
-        yAdjust <<= 16;
-        yAdjust += _yIncrease * feeBase;
+            uint256 _yIncrease = yMid;
+            _yIncrease -= yMin;
+            _yIncrease *= percent;
+            _yIncrease = _yIncrease.shiftRightUp(31);
+            _yIncrease += yMin;
+            yIncrease = _yIncrease.toUint112();
 
-        uint256 _zIncrease = cp.x;
-        _zIncrease *= cp.y;
-        _zIncrease <<= 16;
-        uint256 subtrahend = xAdjust;
-        subtrahend *= yAdjust;
-        _zIncrease -= subtrahend;
-        denominator = xAdjust;
-        denominator *= yAdjust;
-        denominator *= feeBase;
-        _zIncrease = _zIncrease.mulDivUp(uint256(cp.z) << 16, denominator);
-        zIncrease = _zIncrease.toUint112();
+            uint256 yAdjust = cp.y;
+            yAdjust <<= 16;
+            yAdjust += _yIncrease * feeBase;
+
+            uint256 _zIncrease = cp.x;
+            _zIncrease *= cp.y;
+            _zIncrease <<= 16;
+            subtrahend = xAdjust;
+            subtrahend *= yAdjust;
+            _zIncrease -= subtrahend;
+            denominator = xAdjust;
+            denominator *= yAdjust;
+            denominator *= feeBase;
+            _zIncrease = _zIncrease.mulDivUp(uint256(cp.z) << 16, denominator);
+            zIncrease = _zIncrease.toUint112();
+        } else {
+            uint256 zMid = cp.z;
+            zMid *= cp.z;
+            zMid <<= 32;
+            uint256 denominator = xAdjust;
+            denominator *= feeBase;
+            denominator *= feeBase;
+            zMid = zMid.mulDivUp(cp.x, denominator);
+            zMid = zMid.sqrtUp();
+            uint256 subtrahend = cp.z;
+            subtrahend <<= 16;
+            subtrahend /= feeBase;
+            zMid -= subtrahend;
+
+            percent = 0x100000000 - percent;
+
+            uint256 _zIncrease = zMid;
+            _zIncrease *= percent;
+            _zIncrease = _zIncrease.shiftRightUp(31);
+            zIncrease = _zIncrease.toUint112();
+
+            uint256 zAdjust = cp.z;
+            zAdjust <<= 16;
+            zAdjust += _zIncrease * feeBase;
+            uint256 _yIncrease = cp.x;
+            _yIncrease *= cp.z;
+            _yIncrease <<= 16;
+            subtrahend = xAdjust;
+            subtrahend *= zAdjust;
+            _yIncrease -= subtrahend;
+            denominator = xAdjust;
+            denominator *= zAdjust;
+            denominator *= feeBase;
+            _yIncrease = _yIncrease.mulDivUp(uint256(cp.y) << 16, denominator);
+            yIncrease = _yIncrease.toUint112();
+        }
     }
 }

--- a/contracts/libraries/LendMath.sol
+++ b/contracts/libraries/LendMath.sol
@@ -3,12 +3,14 @@ pragma solidity =0.8.4;
 
 import {IPair} from '@timeswap-labs/timeswap-v1-core/contracts/interfaces/IPair.sol';
 import {Math} from '@timeswap-labs/timeswap-v1-core/contracts/libraries/Math.sol';
+import {SquareRoot} from './SquareRoot.sol';
 import {FullMath} from '@timeswap-labs/timeswap-v1-core/contracts/libraries/FullMath.sol';
 import {ConstantProduct} from './ConstantProduct.sol';
 import {SafeCast} from '@timeswap-labs/timeswap-v1-core/contracts/libraries/SafeCast.sol';
 
 library LendMath {
     using Math for uint256;
+    using SquareRoot for uint256;
     using FullMath for uint256;
     using ConstantProduct for IPair;
     using ConstantProduct for ConstantProduct.CP;
@@ -30,12 +32,12 @@ library LendMath {
         _yDecrease = _yDecrease.divUp(maturity - block.timestamp);
         yDecrease = _yDecrease.toUint112();
 
+        uint256 xAdjust = cp.x;
+        xAdjust += assetIn;
+
         uint256 yAdjust = cp.y;
         yAdjust <<= 16;
         yAdjust -= _yDecrease * feeBase;
-
-        uint256 xAdjust = cp.x;
-        xAdjust += assetIn;
 
         uint256 _zDecrease = xAdjust;
         _zDecrease *= yAdjust;
@@ -105,37 +107,85 @@ library LendMath {
         uint256 xAdjust = cp.x;
         xAdjust += assetIn;
 
-        uint256 minimum = assetIn;
-        minimum *= cp.y;
-        minimum <<= 12;
-        uint256 maximum = minimum;
-        maximum <<= 4;
-        uint256 denominator = xAdjust;
-        denominator *= feeBase;
-        minimum /= denominator;
-        maximum /= denominator;
+        if (percent <= 0x80000000) {
+            uint256 yMid = cp.y;
+            yMid <<= 16;
+            yMid /= feeBase;
+            uint256 subtrahend = cp.y;
+            subtrahend *= cp.y;
+            subtrahend <<= 32;
+            uint256 denominator = xAdjust;
+            denominator *= feeBase;
+            denominator *= feeBase;
+            subtrahend = subtrahend.mulDivUp(cp.x, denominator);
+            subtrahend = subtrahend.sqrtUp();
+            yMid -= subtrahend;
 
-        uint256 _yDecrease = maximum;
-        _yDecrease -= minimum;
-        _yDecrease *= percent;
-        _yDecrease >>= 32;
-        _yDecrease += minimum;
-        yDecrease = _yDecrease.toUint112();
+            uint256 yMin = assetIn;
+            yMin *= cp.y;
+            yMin <<= 12;
+            denominator = xAdjust;
+            denominator *= feeBase;
+            yMin /= denominator;
 
-        uint256 yAdjust = cp.y;
-        yAdjust <<= 16;
-        yAdjust -= _yDecrease * feeBase;
+            uint256 _yDecrease = yMid;
+            _yDecrease -= yMin;
+            _yDecrease *= percent;
+            _yDecrease >>= 31;
+            _yDecrease += yMin;
+            yDecrease = _yDecrease.toUint112();
 
-        uint256 _zDecrease = xAdjust;
-        _zDecrease *= yAdjust;
-        uint256 subtrahend = cp.x;
-        subtrahend *= cp.y;
-        subtrahend <<= 16;
-        _zDecrease -= subtrahend;
-        denominator = xAdjust;
-        denominator *= yAdjust;
-        denominator *= feeBase;
-        _zDecrease = _zDecrease.mulDiv(uint256(cp.z) << 16, denominator);
-        zDecrease = _zDecrease.toUint112();
+            uint256 yAdjust = cp.y;
+            yAdjust <<= 16;
+            yAdjust -= _yDecrease * feeBase;
+
+            uint256 _zDecrease = xAdjust;
+            _zDecrease *= yAdjust;
+            subtrahend = cp.x;
+            subtrahend *= cp.y;
+            subtrahend <<= 16;
+            _zDecrease -= subtrahend;
+            denominator = xAdjust;
+            denominator *= yAdjust;
+            denominator *= feeBase;
+            _zDecrease = _zDecrease.mulDiv(uint256(cp.z) << 16, denominator);
+            zDecrease = _zDecrease.toUint112();
+        } else {
+            uint256 zMid = cp.z;
+            zMid <<= 16;
+            zMid /= feeBase;
+            uint256 subtrahend = cp.z;
+            subtrahend *= cp.z;
+            subtrahend << 32;
+            uint256 denominator = xAdjust;
+            denominator *= feeBase;
+            denominator *= feeBase;
+            subtrahend = subtrahend.mulDivUp(cp.x, denominator);
+            subtrahend = subtrahend.sqrtUp();
+            zMid -= subtrahend;
+
+            percent = 0x100000000 - percent;
+
+            uint256 _zDecrease = zMid;
+            _zDecrease *= percent;
+            _zDecrease >>= 31;
+            zDecrease = _zDecrease.toUint112();
+
+            uint256 zAdjust = cp.z;
+            zAdjust <<= 16;
+            zAdjust -= zDecrease * feeBase;
+
+            uint256 _yDecrease = xAdjust;
+            _yDecrease *= zAdjust;
+            subtrahend = cp.x;
+            subtrahend *= cp.z;
+            subtrahend <<= 16;
+            _yDecrease -= subtrahend;
+            denominator = xAdjust;
+            denominator *= zAdjust;
+            denominator *= feeBase;
+            _yDecrease = _yDecrease.mulDiv(uint256(cp.y) << 16, denominator);
+            yDecrease = _yDecrease.toUint112();
+        }
     }
 }

--- a/contracts/libraries/SquareRoot.sol
+++ b/contracts/libraries/SquareRoot.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity =0.8.4;
+
+library SquareRoot {
+    // babylonian method (https://en.wikipedia.org/wiki/Methods_of_computing_square_roots#Babylonian_method)
+    function sqrt(uint256 y) internal pure returns (uint256 z) {
+        if (y > 3) {
+            z = y;
+            uint256 x = y / 2 + 1;
+            while (x < z) {
+                z = x;
+                x = (y / x + x) / 2;
+            }
+        } else if (y != 0) {
+            z = 1;
+        }
+    }
+
+    function sqrtUp(uint256 y) internal pure returns (uint256 z) {
+        z = sqrt(y);
+        if (z % y > 0) z++;
+    }
+}


### PR DESCRIPTION
The givenPercent functions in the LendMath and BorrowMath library has unintended behaviors. Fix it such that the 50%, result in equal proportional increase or decrease to y and z whenever lending or borrowing respectively.