### PR TITLE
Check WETH for zero address

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @timeswap-labs:registry=https://npm.pkg.github.com/
+//npm.pkg.github.com/:_authToken=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

--- a/contracts/TimeswapConvenience.sol
+++ b/contracts/TimeswapConvenience.sol
@@ -61,6 +61,7 @@ contract TimeswapConvenience is IConvenience {
     /// @param _weth The address of the Wrapped ETH contract.
     constructor(IFactory _factory, IWETH _weth) {
         require(address(_weth) != address(0), 'E601');
+
         factory = _factory;
         weth = _weth;
     }


### PR DESCRIPTION
Check that the WETH address is not the zero address in the deployment of the contract, to avoid redeployment.